### PR TITLE
Adding support for two-digit numbers separated by dash (like "thirty-five")

### DIFF
--- a/unit_testing.py
+++ b/unit_testing.py
@@ -13,6 +13,7 @@ class TestW2N(unittest.TestCase):
 		self.assertEqual(w2n.word_to_num('eleven'),11)
 		self.assertEqual(w2n.word_to_num('nineteen billion and nineteen'),19000000019)
 		self.assertEqual(w2n.word_to_num('one hundred and forty two'),142)
+		self.assertEqual(w2n.word_to_num('one hundred thirty-five'),135)
 
 if __name__ == '__main__':
 	unittest.main()

--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -63,6 +63,7 @@ indian_number_system = {
 """
 def word_to_num(number_sentence):
     number_sentence = number_sentence.lower()
+    number_sentence = number_sentence.replace('-', ' ')
     split_words = number_sentence.split()  # split sentence into words
     clean_numbers = []  # removing and, & etc.
     for word in split_words:


### PR DESCRIPTION
Hi! Thank you for the lib. 

I have problem that texts that I analyse contain numbers separated with the dash (like "thirty-five"). I've made a fix for it.
