### PR TITLE
Return None result if no wordnumbers found, print error.

### DIFF
--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -69,9 +69,10 @@ def word_to_num(number_sentence):
         if word in american_number_system:
             clean_numbers.append(word)
 
-    # Error message if the user enters invalid input!        
+    # Print error message if the user enters invalid input, return "None" result
     if len(clean_numbers) == 0:
-        return "Error: Please enter a valid number word (eg. two million twenty three thousand and forty nine) "
+        print("Error: Please enter a valid number word (eg. two million twenty three thousand and forty nine) ")
+	return(None)
 
     billion_index = clean_numbers.index('billion') if 'billion' in clean_numbers else -1
     million_index = clean_numbers.index('million') if 'million' in clean_numbers else -1


### PR DESCRIPTION
Hi there,
  I ran into an issue with the new fix to the IndexError problem.  I had w2n incorporated into a function of mine and counted on an IndexError to move on to the next part.  With the printed error, I was getting that error message returned as part of the function's result.  I tried making a quick fix of that, having it print the error instead and return a None result.

  Is that helpful? I'm a bit of a git newbie, so let me know if I'm contributing incorrectly here.  Thanks for a useful library!
