### PR TITLE
Fix Invalid Output

### DIFF
--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -199,7 +199,7 @@ def word_to_num(number_sentence):
 
             if thousand_index > -1 and thousand_index != len(clean_numbers)-1:
                 hundreds = number_formation(clean_numbers[thousand_index+1:])
-            elif million_index > -1 and million_index != len(clean_numbers)-1:
+            elif million_index > -1 and million_index != len(clean_numbers)-1 and thousand_index != len(clean_numbers)-1:
                 hundreds = number_formation(clean_numbers[million_index+1:])
             elif billion_index > -1 and billion_index != len(clean_numbers)-1:
                 hundreds = number_formation(clean_numbers[billion_index+1:])

--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -201,7 +201,7 @@ def word_to_num(number_sentence):
                 hundreds = number_formation(clean_numbers[thousand_index+1:])
             elif million_index > -1 and million_index != len(clean_numbers)-1 and thousand_index != len(clean_numbers)-1:
                 hundreds = number_formation(clean_numbers[million_index+1:])
-            elif billion_index > -1 and billion_index != len(clean_numbers)-1:
+            elif billion_index > -1 and billion_index != len(clean_numbers)-1 and thousand_index != len(clean_numbers)-1:
                 hundreds = number_formation(clean_numbers[billion_index+1:])
             elif thousand_index == -1 and million_index == -1 and billion_index == -1:
                 hundreds = number_formation(clean_numbers)


### PR DESCRIPTION
Fix https://github.com/akshaynagpal/w2n/issues/24

if you try
`print(w2n.word_to_num('nine billion nine thousand '))`
`print(w2n.word_to_num('nine million nine thousand '))`
it will show invalid output,
the code fix this.
