### PR TITLE
Add regex to fix comma bug

### DIFF
--- a/unit_testing.py
+++ b/unit_testing.py
@@ -32,6 +32,7 @@ class TestW2N(unittest.TestCase):
         self.assertEqual(w2n.word_to_num('billion'), 1000000000)
         self.assertEqual(w2n.word_to_num('nine point nine nine nine'), 9.999)
         self.assertEqual(w2n.word_to_num('seventh point nineteen'), 0)
+        self.assertEqual(w2n.word_to_num('seven million, eight hundred, and sixty three thousand, two hundred, and fifty four'), 7863254)
 
     def test_negatives(self):
         self.assertRaises(ValueError, w2n.word_to_num, '112-')

--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import re
 
 american_number_system = {
     'zero': 0,
@@ -139,7 +140,7 @@ def word_to_num(number_sentence):
     if(number_sentence.isdigit()):  # return the number if user enters a number string
         return int(number_sentence)
 
-    split_words = number_sentence.strip().split()  # strip extra spaces and split sentence into words
+    split_words = re.findall(r'\w+', number_sentence)  # strip extra spaces and split sentence into words
 
     clean_numbers = []
     clean_decimal_numbers = []


### PR DESCRIPTION
Commas between numbers were not being recognized because of the way the words were being split. This pull request uses `re.findall()` to split the sentence into words, ignoring commas and other punctuation between the words.