### PR TITLE
Added support for negative number in words and in numbers.

### DIFF
--- a/unit_testing.py
+++ b/unit_testing.py
@@ -32,8 +32,17 @@ class TestW2N(unittest.TestCase):
         self.assertEqual(w2n.word_to_num('billion'), 1000000000)
         self.assertEqual(w2n.word_to_num('nine point nine nine nine'), 9.999)
         self.assertEqual(w2n.word_to_num('seventh point nineteen'), 0)
+        self.assertEqual(w2n.word_to_num('negative billion'), -1000000000)
+        self.assertEqual(w2n.word_to_num('negative seventh point nineteen'), 0)
+        self.assertEqual(w2n.word_to_num('negative two point three'), -2.3)
+        self.assertEqual(w2n.word_to_num('negative one billion two million twenty three thousand and forty nine point two three six nine'), -1002023049.2369)
+        self.assertEqual(w2n.word_to_num('-4.34'), -4.34)
+        self.assertEqual(w2n.word_to_num('-1002023049.2369'), -1002023049.2369)
+        self.assertEqual(w2n.word_to_num('-100202'), -100202)
+        self.assertEqual(w2n.word_to_num('-135'), -135)
 
     def test_negatives(self):
+        self.assertRaises(ValueError, w2n.word_to_num, 'negative')
         self.assertRaises(ValueError, w2n.word_to_num, '112-')
         self.assertRaises(ValueError, w2n.word_to_num, '-')
         self.assertRaises(ValueError, w2n.word_to_num, 'on')
@@ -43,6 +52,7 @@ class TestW2N(unittest.TestCase):
         self.assertRaises(ValueError, w2n.word_to_num, 'thousand million')
         self.assertRaises(ValueError, w2n.word_to_num, 'one billion point two million twenty three thousand and forty nine point two three six nine')
         self.assertRaises(ValueError, w2n.word_to_num, 112)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/word2number/w2n.py
+++ b/word2number/w2n.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import re
 
 
 american_number_system = {
@@ -34,7 +35,8 @@ american_number_system = {
     'thousand': 1000,
     'million': 1000000,
     'billion': 1000000000,
-    'point': '.'
+    'point': '.',
+    'negative': '-'
 }
 
 decimal_words = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
@@ -133,11 +135,25 @@ def word_to_num(number_sentence):
     if type(number_sentence) is not str:
         raise ValueError("Type of input is not string! Please enter a valid number word (eg. \'two million twenty three thousand and forty nine\')")
 
+    result = re.search(r"[\d.]+", number_sentence)  # Checks if input is a number string
+    if result:  # return the number if user enters a number string or negative number string
+        neg_result = re.search(r"^-[\d.]+", number_sentence)    # Checks if input is a negative number string
+        if neg_result:
+            number_sentence = number_sentence
+        try:
+            answer = int(number_sentence)
+            return answer
+        except ValueError:
+            answer = float(number_sentence)
+            return answer
+
     number_sentence = number_sentence.replace('-', ' ')
     number_sentence = number_sentence.lower()  # converting input to lowercase
 
-    if(number_sentence.isdigit()):  # return the number if user enters a number string
-        return int(number_sentence)
+    is_negative_number = False  
+    if "negative" in number_sentence:   # check if negative is in input
+        is_negative_number = True   # set is_negative_number to true
+        number_sentence = number_sentence.lstrip('negative')
 
     split_words = number_sentence.strip().split()  # strip extra spaces and split sentence into words
 
@@ -154,7 +170,7 @@ def word_to_num(number_sentence):
         raise ValueError("No valid number words found! Please enter a valid number word (eg. two million twenty three thousand and forty nine)") 
 
     # Error if user enters million,billion, thousand or decimal point twice
-    if clean_numbers.count('thousand') > 1 or clean_numbers.count('million') > 1 or clean_numbers.count('billion') > 1 or clean_numbers.count('point')> 1:
+    if clean_numbers.count('thousand') > 1 or clean_numbers.count('million') > 1 or clean_numbers.count('billion') > 1 or clean_numbers.count('point') > 1:
         raise ValueError("Redundant number word! Please enter a valid number word (eg. two million twenty three thousand and forty nine)")
 
     # separate decimal part of number (if exists)
@@ -166,7 +182,7 @@ def word_to_num(number_sentence):
     million_index = clean_numbers.index('million') if 'million' in clean_numbers else -1
     thousand_index = clean_numbers.index('thousand') if 'thousand' in clean_numbers else -1
 
-    if (thousand_index > -1 and (thousand_index < million_index or thousand_index < billion_index)) or (million_index>-1 and million_index < billion_index):
+    if (thousand_index > -1 and (thousand_index < million_index or thousand_index < billion_index)) or (million_index > -1 and million_index < billion_index):
         raise ValueError("Malformed number! Please enter a valid number word (eg. two million twenty three thousand and forty nine)")
 
     total_sum = 0  # storing the number to be returned
@@ -174,7 +190,7 @@ def word_to_num(number_sentence):
     if len(clean_numbers) > 0:
         # hack for now, better way TODO
         if len(clean_numbers) == 1:
-                total_sum += american_number_system[clean_numbers[0]]
+            total_sum += american_number_system[clean_numbers[0]]
 
         else:
             if billion_index > -1:
@@ -213,5 +229,15 @@ def word_to_num(number_sentence):
     if len(clean_decimal_numbers) > 0:
         decimal_sum = get_decimal_sum(clean_decimal_numbers)
         total_sum += decimal_sum
+
+    if is_negative_number is True:
+        if type(total_sum) is float:    # returns a float point number
+            add_negative = str(american_number_system['negative']) + str(total_sum)
+            total_sum = float(add_negative)
+            return total_sum
+        # returns an integer number
+        add_negative = str(american_number_system['negative']) + str(total_sum)
+        total_sum = int(add_negative)
+        return total_sum
 
     return total_sum


### PR DESCRIPTION
Okay so I recently, came across this package and I must say I enjoyed it. I needed to change the negative number in words to numbers. This is where I realised the feature was not yet supported. Since the package is really helpful, I am opting to contribute to it by adding support for negative numbers.

From the issues, I saw this feature has been asked by many and you had asked the person whether negative number are common thing in sentences or number words [](https://github.com/akshaynagpal/w2n/issues/33#issuecomment-473129015). Well, in my opinion, they are and I have listed just a few applications of it in sentences.

**Application of negative number in common sentence with some links proving them**

- From Wikipedia (https://en.wikipedia.org/wiki/Negative_number) = Negative numbers are used to describe values on a scale that goes below zero, such as the Celsius and Fahrenheit scales for temperature. For example, The temperature is at negative 20 Celsius.
- From Story of Mathematics (https://www.storyofmathematics.com/negative-numbers) = Negatives numbers are used for arithmetic calculations. For example Two plus negative eight. Multiply ten by negative 18.

These and many more are examples to prove that negative is used in common sentences. **_Also, this module is to change a number in words to numbers for arithmetic calculations so the feature is very important._**

That being said I think adding the ability to handle negatives will be important. I would love to get a response from you and the team. 

**Thanks**.