### PR TITLE
Add a mypy stub

### DIFF
--- a/word2number/w2n.pyi
+++ b/word2number/w2n.pyi
@@ -1,0 +1,10 @@
+from typing import List, Union
+
+def number_formation(number_words: List[str]) -> int:
+    pass
+
+def get_decimal_sum(decimal_digit_words: List[str]) -> float:
+    pass
+
+def word_to_num(number_sentence: str) -> Union[int, float, None]:
+    pass


### PR DESCRIPTION
A mypy compatible stub file as per https://mypy.readthedocs.io/en/stable/stubs.html, using types annotations that mirror the comments in w2n.py.

This is needed to use this library in a project that uses mypy, otherwise the following error will be returned by mypy:
`error: Skipping analyzing 'word2number': found module but no type hints or library stubs`